### PR TITLE
Switch from SSR to SSG

### DIFF
--- a/pages/episodes/[id].tsx
+++ b/pages/episodes/[id].tsx
@@ -2,9 +2,9 @@ import EpisodeComponent from "@/components/Episode";
 import Header from "@/components/Header";
 import Page from "@/components/Page";
 import Seo from "@/components/Seo";
-import { GetServerSidePropsContext } from "next";
+import { GetStaticPropsContext } from "next";
 import { Item, Output } from "rss-parser";
-import { getEpisode } from "@/lib/rss";
+import { getEpisode, getPodcast } from "@/lib/rss";
 
 interface EpisodeProps {
   podcast: Output<Item>;
@@ -35,9 +35,7 @@ export default function Episode({ podcast, episode }: EpisodeProps) {
   );
 }
 
-export async function getServerSideProps({
-  params,
-}: GetServerSidePropsContext) {
+export async function getStaticProps({ params }: GetStaticPropsContext) {
   const id = params?.id as string;
 
   if (!id) {
@@ -56,5 +54,18 @@ export async function getServerSideProps({
 
   return {
     props: result,
+  };
+}
+
+export async function getStaticPaths() {
+  const podcast = await getPodcast();
+
+  return {
+    paths: podcast.items.map((episode) => {
+      return {
+        params: { id: episode.guid },
+      };
+    }),
+    fallback: false,
   };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,12 +2,12 @@ import Episodes from "@/components/Episodes";
 import Header from "@/components/Header";
 import Page from "@/components/Page";
 import Seo from "@/components/Seo";
-import { InferGetServerSidePropsType } from "next";
+import { InferGetStaticPropsType } from "next";
 import { getPodcast } from "@/lib/rss";
 
 export default function Home({
   podcast,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
       <Seo description={podcast.description} title={podcast.title} />
@@ -23,7 +23,7 @@ export default function Home({
   );
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const podcast = await getPodcast();
 
   return {


### PR DESCRIPTION
## Changes

- Instead of fetching the RSS feed everytime you visit the page, and the episodes everytime you go the a specific episode page, we're not using `getStaticProps`, which fetches everything in build-time. Our page will be a lot faster using this. We just have to rebuild our site if we publish a new episode, but there should be some webhook in Anchor for that. This is how Syntax does it.